### PR TITLE
Correct test-assertion error-messages

### DIFF
--- a/tests/TestF_comparisons.cpp
+++ b/tests/TestF_comparisons.cpp
@@ -26,7 +26,7 @@ int main() {
     list.push_back(42.0);
     [[maybe_unused]] auto begin = list.begin(); // obtain iterator to begin
     [[maybe_unused]] auto end = list.end();     // obtain iterator to end
-    TEST_ASSERT(begin != end, "begin is end for empty list");
+    TEST_ASSERT(begin != end, "begin is end for non-empty list");
   }
 
   return 0;

--- a/tests/TestH_const_access.cpp
+++ b/tests/TestH_const_access.cpp
@@ -30,15 +30,15 @@ int main() {
         "cbegin does not return iterator with const access");
     static_assert(
         std::is_same<decltype(List<T>{}.cend())::value_type, const T>::value,
-        "cbegin does not return iterator with const access");
+        "cend does not return iterator with const access");
   }
 
   { // check if begin and end return iterators providing non-const access
     static_assert(
         std::is_same<decltype(List<T>{}.begin())::value_type, T>::value,
-        "cbegin does not return iterator with const access");
+        "begin does not return iterator with const access");
     static_assert(std::is_same<decltype(List<T>{}.end())::value_type, T>::value,
-                  "cbegin does not return iterator with const access");
+                  "end does not return iterator with const access");
   }
 
   { // check if begin and end obtained from a const list result in iterators
@@ -46,7 +46,7 @@ int main() {
     List<T> list;
     list.push_back(1.0);
     [[maybe_unused]] const List<T> &clist = list;
- 
+
     static_assert(
         !std::is_same<decltype(clist.begin())::value_type, T>::value,
         "begin does not return iterator with const access for const list");


### PR DESCRIPTION
This should correct a few of the test-assertion error-messages that, at least to
me, seem to be misguiding.
